### PR TITLE
Fix int conversion warning

### DIFF
--- a/SecureUDID.m
+++ b/SecureUDID.m
@@ -209,7 +209,7 @@ UIPasteboard *pasteboardForEncryptedDomain(NSData *encryptedDomain) {
     NSMutableDictionary* mostRecentDictionary;
     
     usablePasteboard     = nil;
-    lowestUnusedIndex    = INT32_MAX;
+    lowestUnusedIndex    = -1;
     mostRecentDate       = [NSDate distantPast];
     mostRecentDictionary = nil;
     


### PR DESCRIPTION
The code was assigning a long long to an int, letting it get clipped to -1, and then relying on that fact. Now it just uses -1
