### PR TITLE
Fix potential memory leak in SUUIDModelHash

### DIFF
--- a/SecureUDID.m
+++ b/SecureUDID.m
@@ -256,23 +256,17 @@ NSData *SUUIDHash(NSData *data) {
 NSData* SUUIDModelHash(void) {
     NSString* result;
     
-    result = @"Unknown";
+    result = nil;
     
     do {
         size_t size;
-        char*  value;
-        
-        value  = NULL;
         
         // first get the size
         if (sysctlbyname("hw.machine", NULL, &size, NULL, 0) != 0) {
             break;
         }
         
-        value = malloc(size);
-        if (!value) {
-            break;
-        }
+        char value[size];
         
         // now get the value
         if (sysctlbyname("hw.machine", value, &size, NULL, 0) != 0) {
@@ -281,13 +275,11 @@ NSData* SUUIDModelHash(void) {
         
         // convert the value to an NSString
         result = [NSString stringWithCString:value encoding:NSUTF8StringEncoding];
-        if (!result) {
-            break;
-        }
-        
-        // free our buffer
-        free(value);
     } while (0);
+    
+    if (!result) {
+        result = @"Unknown";
+    }
     
     return SUUIDHash([result dataUsingEncoding:NSUTF8StringEncoding]);
 }


### PR DESCRIPTION
This leak (caught by the static analyzer) would occur if the do-while loop hit a break before free() was called. Instead of allocating memory on the heap, it is now being dynamically allocated on the stack.

Additionally, there was a (very) small chance that the 'result' string would be nil if for some crazy reason the returned value for 'hw.machine' was not a proper UTF-8 encoded string. However unlikely for that to occur, the code was changed for correctness.
